### PR TITLE
fix: better horizontal scroll

### DIFF
--- a/docs/components/Demo.tsx
+++ b/docs/components/Demo.tsx
@@ -1,11 +1,9 @@
 import faker from '@faker-js/faker';
 import {
     Badge,
-    Box,
-    Divider,
-    Highlight,
+    createStyles,
+    Grid,
     MantineSize,
-    Mark,
     MultiSelect,
     Slider,
     Space,
@@ -29,8 +27,9 @@ type Data = {
     bool: boolean;
 };
 
-function genFakerData() {
+function genFakerData(_: any, i: number) {
     return {
+        id: i + 1,
         text: faker.lorem.lines(),
         cat: faker.animal.cat(),
         fish: faker.animal.fish(),
@@ -83,7 +82,23 @@ catFilter.element = function ({ filter, onFilterChange }) {
     );
 };
 
+const useStyles = createStyles((theme) => ({
+    gridWrapper: {
+        display: 'flex',
+        alignItems: 'stretch',
+        width: "100%",
+        marginTop: theme.spacing.lg
+    },
+    gridProps: {
+        borderLeftWidth: 1,
+        borderLeftStyle: "solid",
+        borderLeftColor: theme.colors.gray[6],
+    },
+}));
+
 export default function Demo() {
+    const { classes } = useStyles();
+
     const initialPageIndex = 0;
     const initialPageSize = 10;
 
@@ -109,8 +124,8 @@ export default function Demo() {
     };
 
     return (
-        <div style={{ display: 'flex', alignItems: 'stretch' }}>
-            <Box p="md" style={{ flexGrow: 1 }}>
+        <Grid className={classes.gridWrapper}>
+            <Grid.Col span={10} p="md">
                 <DataGrid
                     debug
                     striped={state.striped}
@@ -128,6 +143,11 @@ export default function Demo() {
                     }}
                     onPageChange={onPageChange}
                     columns={[
+                        {
+                            accessorKey: 'id',
+                            header: 'No',
+                            size: 60,
+                        },
                         {
                             accessorKey: 'text',
                             header: 'Text that is too long for a Header',
@@ -168,11 +188,8 @@ export default function Demo() {
                         },
                     ]}
                 />
-            </Box>
-            <div>
-                <Divider orientation="vertical" />
-            </div>
-            <Box p="md">
+            </Grid.Col>
+            <Grid.Col span={2} p="md" className={classes.gridProps}>
                 <Stack>
                     <Title order={2}>Properties</Title>
 
@@ -287,7 +304,7 @@ export default function Demo() {
                         />
                     </div>
                 </Stack>
-            </Box>
-        </div>
+            </Grid.Col>
+        </Grid>
     );
 }

--- a/docs/components/Properties.tsx
+++ b/docs/components/Properties.tsx
@@ -118,7 +118,7 @@ export default function Properties() {
                             <Text
                                 size="sm"
                                 color="orange"
-                                children="{ initialPageIndex: number; initialPageSize: number; }"
+                                children="{ initialPageIndex?: number; initialPageSize?: number; pageSizes?: string[]; }"
                             />
                         </td>
                         <td>

--- a/docs/main.tsx
+++ b/docs/main.tsx
@@ -2,13 +2,10 @@ import {
     Button,
     Center,
     MantineProvider,
-    Stack,
     Title,
     Paper,
     Tabs,
-    Container,
     Grid,
-    Space,
     Group,
 } from '@mantine/core';
 import React from 'react';

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { ScrollArea, Stack, Table as MantineTable } from '@mantine/core';
 import {
-    ColumnDef,
     ColumnSizingInfoState,
-    FilterFn,
     flexRender,
     getCoreRowModel,
     getFilteredRowModel,
@@ -139,118 +137,121 @@ export function DataGrid<TData extends RowData>({
                     className={classes.globalFilter}
                 />
             )}
-            <MantineTable
-                striped={striped}
-                highlightOnHover={highlightOnHover}
-                horizontalSpacing={horizontalSpacing}
-                verticalSpacing={verticalSpacing}
-                fontSize={fontSize}
-                className={classes.table}
-            >
-                <thead className={classes.header} role="rowgroup">
-                    {table
-                        .getHeaderGroups()
-                        .map((group, groupIndex, headerGroups) => (
-                            <tr
-                                key={group.id}
-                                className={classes.row}
-                                role="row"
-                            >
-                                {group.headers.map((header, headerIndex) => (
-                                    <th
-                                        key={header.id}
-                                        style={{
-                                            width: header.getSize(),
-                                        }}
-                                        className={cx(classes.headerCell)}
-                                        role="columnheader"
-                                    >
-                                        {!header.isPlaceholder && (
-                                            <>
-                                                <div
-                                                    className={cx({
-                                                        [classes.ellipsis]:
-                                                            !noEllipsis,
-                                                    })}
-                                                >
-                                                    {flexRender(
-                                                        header.column.columnDef
-                                                            .header,
-                                                        header.getContext()
-                                                    )}
-                                                </div>
-                                                <div
-                                                    className={
-                                                        classes.headerCellButtons
-                                                    }
-                                                >
-                                                    {header.column.getCanSort() && (
-                                                        <ColumnSorter
-                                                            className={
-                                                                classes.sorter
-                                                            }
-                                                            column={
-                                                                header.column
-                                                            }
-                                                        />
-                                                    )}
-                                                    {header.column.getCanFilter() && (
-                                                        <ColumnFilter
-                                                            className={
-                                                                classes.filter
-                                                            }
-                                                            column={
-                                                                header.column
-                                                            }
-                                                        />
-                                                    )}
-                                                </div>
-                                                {header.column.getCanResize() && (
+            <ScrollArea>
+                <MantineTable
+                    striped={striped}
+                    highlightOnHover={highlightOnHover}
+                    horizontalSpacing={horizontalSpacing}
+                    verticalSpacing={verticalSpacing}
+                    fontSize={fontSize}
+                    className={classes.table}
+                >
+                    <thead className={classes.header} role="rowgroup">
+                        {table
+                            .getHeaderGroups()
+                            .map((group, groupIndex, headerGroups) => (
+                                <tr
+                                    key={group.id}
+                                    className={classes.row}
+                                    role="row"
+                                >
+                                    {group.headers.map((header, headerIndex) => (
+                                        <th
+                                            key={header.id}
+                                            style={{
+                                                width: header.getSize(),
+                                            }}
+                                            className={cx(classes.headerCell)}
+                                            role="columnheader"
+                                        >
+                                            {!header.isPlaceholder && (
+                                                <>
+                                                    <div
+                                                        className={cx({
+                                                            [classes.ellipsis]:
+                                                                !noEllipsis,
+                                                        })}
+                                                    >
+                                                        {flexRender(
+                                                            header.column.columnDef
+                                                                .header,
+                                                            header.getContext()
+                                                        )}
+                                                    </div>
                                                     <div
                                                         className={
-                                                            classes.resizer
+                                                            classes.headerCellButtons
                                                         }
-                                                        onClick={(e) =>
-                                                            e.stopPropagation()
-                                                        }
-                                                        onMouseDown={header.getResizeHandler()}
-                                                        onTouchStart={header.getResizeHandler()}
-                                                    />
-                                                )}
-                                            </>
+                                                    >
+                                                        {header.column.getCanSort() && (
+                                                            <ColumnSorter
+                                                                className={
+                                                                    classes.sorter
+                                                                }
+                                                                column={
+                                                                    header.column
+                                                                }
+                                                            />
+                                                        )}
+                                                        {header.column.getCanFilter() && (
+                                                            <ColumnFilter
+                                                                className={
+                                                                    classes.filter
+                                                                }
+                                                                column={
+                                                                    header.column
+                                                                }
+                                                            />
+                                                        )}
+                                                    </div>
+                                                    {header.column.getCanResize() && (
+                                                        <div
+                                                            className={
+                                                                classes.resizer
+                                                            }
+                                                            onClick={(e) =>
+                                                                e.stopPropagation()
+                                                            }
+                                                            onMouseDown={header.getResizeHandler()}
+                                                            onTouchStart={header.getResizeHandler()}
+                                                        />
+                                                    )}
+                                                </>
+                                            )}
+                                        </th>
+                                    ))}
+                                </tr>
+                            ))}
+                    </thead>
+                    <tbody className={classes.body} role="rowgroup">
+                        {table.getRowModel().rows.map((row) => (
+                            <tr key={row.id} className={classes.row} role="row">
+                                {row.getVisibleCells().map((cell) => (
+                                    <td
+                                        key={cell.id}
+                                        style={{
+                                            width: cell.column.getSize(),
+                                        }}
+                                        className={cx(classes.dataCell, {
+                                            [classes.ellipsis]: !noEllipsis,
+                                        })}
+                                        children={flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext()
                                         )}
-                                    </th>
+                                        role="cell"
+                                    />
                                 ))}
                             </tr>
                         ))}
-                </thead>
-                <tbody className={classes.body} role="rowgroup">
-                    {table.getRowModel().rows.map((row) => (
-                        <tr key={row.id} className={classes.row} role="row">
-                            {row.getVisibleCells().map((cell) => (
-                                <td
-                                    key={cell.id}
-                                    style={{
-                                        width: cell.column.getSize(),
-                                    }}
-                                    className={cx(classes.dataCell, {
-                                        [classes.ellipsis]: !noEllipsis,
-                                    })}
-                                    children={flexRender(
-                                        cell.column.columnDef.cell,
-                                        cell.getContext()
-                                    )}
-                                    role="cell"
-                                />
-                            ))}
-                        </tr>
-                    ))}
-                </tbody>
-            </MantineTable>
+                    </tbody>
+                </MantineTable>
+            </ScrollArea>
             {withPagination && (
                 <Pagination
                     table={table}
                     onPageChange={onPageChange}
+                    pageSizes={pagination?.pageSizes}
                     className={classes.pagination}
                 />
             )}

--- a/src/GlobalFilter.tsx
+++ b/src/GlobalFilter.tsx
@@ -31,7 +31,7 @@ export function GlobalFilter({
         <TextInput
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            placeholder="Search"
+            placeholder="Search..."
             rightSection={<Search />}
             className={className}
         />

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -1,14 +1,19 @@
-import { Divider, Group, Select, Text,
+import {
+  Divider,
+  Group,
+  Select,
+  Text,
   Pagination as MantinePagination,
-  Stack,
-  Box} from "@mantine/core";
+  Stack
+} from "@mantine/core";
+
 import { OnPageChangeCallback } from "./types";
 
-export const DEFAULT_PAGE_OPTIONS = ["10", "25", "50", "100"];
+export const DEFAULT_PAGE_SIZES = ["10", "25", "50", "100"];
 export const DEFAULT_INITIAL_PAGE = 0;
 export const DEFAULT_INITIAL_SIZE = 10;
 
-export function Pagination({ table, onPageChange, className = 'pagination' }: { table: any, onPageChange: OnPageChangeCallback, className: string }) {
+export function Pagination({ table, onPageChange, className = 'pagination', pageSizes = DEFAULT_PAGE_SIZES }: { table: any, onPageChange: OnPageChangeCallback, className: string, pageSizes?: string[] }) {
 
   const { rows: allRows } = table.getCoreRowModel();
   const pageIndex = table.getState().pagination.pageIndex;
@@ -47,15 +52,15 @@ export function Pagination({ table, onPageChange, className = 'pagination' }: { 
   return (
     <Stack className={className}>
       <Group position="apart">
-          <Text size="sm" className={`${className}-info`}>
-            Showing <b>{firstRowNum}</b> - <b>{lastRowNum}</b> of <b>{allRows.length}</b> result
-          </Text>
+        <Text size="sm" className={`${className}-info`}>
+          Showing <b>{firstRowNum}</b> - <b>{lastRowNum}</b> of <b>{allRows.length}</b> result
+        </Text>
         <Group >
           <Text size="sm">Rows per page: </Text>
           <Select
             style={{ width: "72px" }}
             variant="filled"
-            data={DEFAULT_PAGE_OPTIONS}
+            data={pageSizes}
             value={`${table.getState().pagination.pageSize}`}
             onChange={handlePageSizeChange}
             className={`${className}-size`}

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,9 +68,24 @@ export interface DataGridProps<TData extends RowData>
     fontSize?: MantineNumberSize;
     /** Enables pagination */
     withPagination?: boolean;
+    /** Pagination additional setup */
     pagination?: {
-        initialPageIndex: number;
-        initialPageSize: number;
+        /**
+         * An initial current page index.
+         * Default is `0` */
+        initialPageIndex?: number;
+        /**
+         * An initial current page size (rows per page).
+         * Default is `10`  */
+        initialPageSize?: number;
+        /**
+         * Sets of string for page size (rows per page) selections.
+         * Default is `["10", "25", "50", "100"]`
+         * */
+        pageSizes?: string[];
     };
+    /**
+     * Callback when page index or page size changed
+     * */
     onPageChange?: OnPageChangeCallback;
 }


### PR DESCRIPTION
- [x] Fix the layout to not over 100% width
- [x] Better horizontal scroll by wrapping it in `<ScrollArea>`
- [x] Add new props `pagination.pageSizes` to set pageSize selections

<img width="1335" alt="Screen Shot 2022-07-21 at 14 12 04" src="https://user-images.githubusercontent.com/7221389/180152440-7b48847f-2976-46ac-b0d5-5dd45004ce62.png">


Live page for test: https://mazipan.github.io/mantine-data-grid/