### PR TITLE
[FIX] when using pagination, can't navigate to last page if nb of rows is not a multiple of page size

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -155,7 +155,7 @@ export function DataGrid<TData extends RowData>({
     const pageCount = withPagination
         ? total
             ? Math.floor(total / table.getState().pagination.pageSize)
-            : Math.floor(data.length / table.getState().pagination.pageSize)
+            : Math.ceil(data.length / table.getState().pagination.pageSize)
         : -1;
 
     table.setOptions((prev) => ({
@@ -308,6 +308,7 @@ export function DataGrid<TData extends RowData>({
             </ScrollArea>
             {withPagination && (
                 <Pagination
+                    nbRows={data.length}
                     table={table}
                     pageSizes={pageSizes}
                     className={classes.pagination}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -308,7 +308,7 @@ export function DataGrid<TData extends RowData>({
             </ScrollArea>
             {withPagination && (
                 <Pagination
-                    nbRows={data.length}
+                    totalRows={data.length}
                     table={table}
                     pageSizes={pageSizes}
                     className={classes.pagination}

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -14,22 +14,22 @@ export const DEFAULT_INITIAL_SIZE = 10;
 
 export function Pagination({
     table,
+    nbRows,
     className = 'pagination',
     pageSizes = DEFAULT_PAGE_SIZES,
 }: {
     table: Table<any>;
+    nbRows: number;
     className: string;
     pageSizes?: string[];
 }) {
     const pageIndex = table.getState().pagination.pageIndex;
     const pageSize = table.getState().pagination.pageSize;
 
-    const allRows = table.getPageCount() * pageSize;
-
     const firstRowNum = pageIndex * pageSize + 1;
 
     const currLastRowNum = (pageIndex + 1) * pageSize;
-    const lastRowNum = currLastRowNum < allRows ? currLastRowNum : allRows;
+    const lastRowNum = currLastRowNum < nbRows ? currLastRowNum : nbRows;
 
     const handlePageSizeChange = (value: string) => {
         table.setPageSize(Number(value));
@@ -44,7 +44,7 @@ export function Pagination({
             <Group position="apart">
                 <Text size="sm" className={`${className}-info`}>
                     Showing <b>{firstRowNum}</b> - <b>{lastRowNum}</b> of{' '}
-                    <b>{allRows}</b> result
+                    <b>{nbRows}</b> result
                 </Text>
                 <Group>
                     <Text size="sm">Rows per page: </Text>

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -14,12 +14,12 @@ export const DEFAULT_INITIAL_SIZE = 10;
 
 export function Pagination({
     table,
-    nbRows,
+    totalRows,
     className = 'pagination',
     pageSizes = DEFAULT_PAGE_SIZES,
 }: {
     table: Table<any>;
-    nbRows: number;
+    totalRows: number;
     className: string;
     pageSizes?: string[];
 }) {
@@ -29,7 +29,7 @@ export function Pagination({
     const firstRowNum = pageIndex * pageSize + 1;
 
     const currLastRowNum = (pageIndex + 1) * pageSize;
-    const lastRowNum = currLastRowNum < nbRows ? currLastRowNum : nbRows;
+    const lastRowNum = currLastRowNum < totalRows ? currLastRowNum : totalRows;
 
     const handlePageSizeChange = (value: string) => {
         table.setPageSize(Number(value));
@@ -44,7 +44,7 @@ export function Pagination({
             <Group position="apart">
                 <Text size="sm" className={`${className}-info`}>
                     Showing <b>{firstRowNum}</b> - <b>{lastRowNum}</b> of{' '}
-                    <b>{nbRows}</b> result
+                    <b>{totalRows}</b> result
                 </Text>
                 <Group>
                     <Text size="sm">Rows per page: </Text>


### PR DESCRIPTION
First, thanks for your work!

I've noticed a small bug using your library: if the number of rows is not a multiple of the page size when using pagination, we can't navigate to the last page. 

You can reproduce it by changing:
```typescript
export const demoData: Data[] = new Array(10_000).fill({}).map(genFakerData);
```
into
```typescript
export const demoData: Data[] = new Array(11).fill({}).map(genFakerData);
```