### PR TITLE
fix: headerFixed to withFixedHeader in state obj on demo page

### DIFF
--- a/docs/components/Demo.tsx
+++ b/docs/components/Demo.tsx
@@ -91,7 +91,7 @@ export default function Demo() {
     verticalSpacing: 'xs' as MantineSize,
     fontSize: 'md' as MantineSize,
     height: 0,
-    headerFixed: false,
+    withFixedHeader: false,
     noEllipsis: false,
     withGlobalFilter: true,
     withPagination: true,
@@ -233,10 +233,10 @@ export default function Demo() {
           />
           <Switch
             label="With fixed Header"
-            checked={state.headerFixed}
+            checked={state.withFixedHeader}
             onChange={(e) =>
               update({
-                headerFixed: e.target.checked,
+                withFixedHeader: e.target.checked,
               })
             }
           />


### PR DESCRIPTION
Fixed a little state property in demo page headerFixed to withFixedHeader which was not working on changing the input state in demo 