### PR TITLE
fix(pagination): set static size to match page size select

### DIFF
--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -56,6 +56,13 @@ export function Pagination<TData>({
         </Box>
         <MantinePagination
           size={fontSize}
+          /** Read: https://github.com/mantinedev/mantine/discussions/2001 */
+          sx={() => ({
+            '> button': {
+              height: '36px',
+              minWidth: '36px',
+            },
+          })}
           page={table.getState().pagination.pageIndex + 1}
           total={table.getPageCount()}
           onChange={handlePageChange}


### PR DESCRIPTION
Closes #57

## Description

Set static size for action button use by pagination to match the page size select component.

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Set height and minWidth

## Live Demo Link

https://mazipan.github.io/mantine-data-grid/
