### PR TITLE
fix: page count with filtered data

### DIFF
--- a/docs/pages/examples/AsyncExample.tsx
+++ b/docs/pages/examples/AsyncExample.tsx
@@ -18,28 +18,39 @@ type FetchResponse = {
   total: number;
 };
 
-function fetchData(page: number, pageSize: number): Promise<FetchResponse> {
+function fetchData(page: number, pageSize: number, search: string): Promise<FetchResponse> {
   return new Promise((resolve) =>
-    setTimeout(
-      () =>
-        resolve({
-          list: demoData.slice(page * pageSize, page * pageSize + pageSize),
-          total: demoData.length,
-        }),
-      1000
-    )
+    setTimeout(() => {
+      const data = demoData.filter(
+        (x) => x.text.includes(search) || x.cat.includes(search) || x.fish.includes(search) || x.city.includes(search)
+      );
+      resolve({
+        list: data.slice(page * pageSize, page * pageSize + pageSize),
+        total: data.length + 2,
+      });
+    }, 1000)
   );
 }
 
 export default function AsyncExample() {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<FetchResponse>({ list: [], total: 0 });
+  const [searchValue, setSearchValue] = useState<string>('');
 
   const load: OnChangeCallback<DataGridPaginationState> = async ({ pageIndex, pageSize }) => {
     console.log(`pageIndex: ${pageIndex}, pageSize: ${pageSize}`);
     setLoading(true);
-    const res = await fetchData(pageIndex, pageSize);
+    const res = await fetchData(pageIndex, pageSize, searchValue);
     setData(res);
+    setLoading(false);
+  };
+
+  const search: OnChangeCallback<string> = async (val) => {
+    console.log(`search`);
+    setLoading(true);
+    const res = await fetchData(0, 10, val);
+    setData(res);
+    setSearchValue(val);
     setLoading(false);
   };
 
@@ -53,7 +64,9 @@ export default function AsyncExample() {
         data={data.list}
         total={data.total}
         onPageChange={load}
+        onSearch={search}
         withPagination
+        withGlobalFilter
         loading={loading}
         columns={[
           {
@@ -110,34 +123,38 @@ type FetchResponse = {
     total: number;
 };
 
-function fetchData(page: number, pageSize: number): Promise<FetchResponse> {
-    return new Promise((resolve) =>
-        setTimeout(
-            () =>
-                resolve({
-                    list: demoData.slice(
-                        page * pageSize,
-                        page * pageSize + pageSize
-                    ),
-                    total: demoData.length,
-                }),
-            100
-        )
-    );
+function fetchData(page: number, pageSize: number, search: string): Promise<FetchResponse> {
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      const data = demoData.filter(
+        (x) => x.text.includes(search) || x.cat.includes(search) || x.fish.includes(search) || x.city.includes(search)
+      );
+      resolve({
+        list: data.slice(page * pageSize, page * pageSize + pageSize),
+        total: data.length + 2,
+      });
+    }, 1000)
+  );
 }
 
 export default function AsyncExample() {
     const [loading, setLoading] = useState(false);
     const [data, setData] = useState<FetchResponse>({ list: [], total: 0 });
+    const [searchValue, setSearchValue] = useState<string>('');
 
-    const load: OnChangeCallback<DataGridPaginationState> = async ({
-        pageIndex,
-        pageSize,
-    }) => {
-        setLoading(true);
-        var res = await fetchData(pageIndex, pageSize);
-        setData(res);
-        setLoading(false);
+    const load: OnChangeCallback<DataGridPaginationState> = async ({ pageIndex, pageSize }) => {
+      setLoading(true);
+      const res = await fetchData(pageIndex, pageSize, searchValue);
+      setData(res);
+      setLoading(false);
+    };
+
+    const search: OnChangeCallback<string> = async (val) => {
+      setLoading(true);
+      const res = await fetchData(0, 10, val);
+      setData(res);
+      setSearchValue(val);
+      setLoading(false);
     };
 
     useEffect(() => {
@@ -149,7 +166,9 @@ export default function AsyncExample() {
             data={data.list}
             total={data.total}
             onPageChange={load}
+            onSearch={search}
             withPagination
+            withGlobalFilter
             loading={loading}
             columns={[
                 {

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -86,9 +86,9 @@ export function DataGrid<TData extends RowData>({
     manualPagination: !!total, // when external data, handle pagination manually
 
     getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
 
     debugTable: debug,
     debugHeaders: debug,
@@ -153,18 +153,11 @@ export function DataGrid<TData extends RowData>({
     [onPageChange]
   );
 
-  const pageCount = withPagination
-    ? total
-      ? Math.floor(total / table.getState().pagination.pageSize)
-      : Math.ceil(data.length / table.getState().pagination.pageSize)
-    : -1;
+  const pageCount = withPagination && total ? Math.ceil(total / table.getState().pagination.pageSize) : undefined;
 
   table.setOptions((prev) => ({
     ...prev,
     pageCount,
-    state: {
-      ...prev.state,
-    },
     onGlobalFilterChange: handleGlobalFilterChange,
     onColumnFiltersChange: handleColumnFiltersChange,
     onSortingChange: handleSortingChange,


### PR DESCRIPTION
Closes #56<!-- mention the issue that you're trying to close with this PR -->

## Description

<!-- Describe your implementation plan and approach -->
When Filtering a grid, the page count is not updated to the correct count of filtered pages.

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] only calculte page count when tolal value is supplied
- [x] update async example to include global filter
