### PR TITLE
feat: add compact pagination mode

### DIFF
--- a/docs/components/PropertyTable.tsx
+++ b/docs/components/PropertyTable.tsx
@@ -20,6 +20,7 @@ const useStyles = createStyles((t) => ({
   },
   subtile: {
     borderBottom: '1px solid ' + t.colors.dark[2] + ' !important',
+    paddingTop: `${t.spacing.lg}px !important`,
   },
   cell: { whiteSpace: 'pre-wrap' },
 }));
@@ -47,7 +48,7 @@ export const PropertyTable = ({ groups, items }: PropertyTableProps) => {
     <Fragment key={group.group}>
       <tr>
         <td colSpan={3} className={classes.subtile}>
-          <Text weight="bold" size="xs" color="dimmed">
+          <Text weight="bold" size="md" color="dimmed">
             {group.group}
           </Text>
         </td>

--- a/docs/pages/Demo.tsx
+++ b/docs/pages/Demo.tsx
@@ -106,6 +106,7 @@ export default function Demo() {
     loading: false,
     showEmpty: false,
     iconColor: theme.primaryColor,
+    paginationCompactMode: false,
   });
 
   const onPageChange = (e: DataGridPaginationState) => {
@@ -155,6 +156,7 @@ export default function Demo() {
           onSort={onSort}
           onFilter={onFilter}
           onSearch={onSearch}
+          paginationMode={state.paginationCompactMode ? 'compact' : 'default'}
           columns={[
             {
               accessorKey: 'id',
@@ -348,6 +350,17 @@ export default function Demo() {
               })
             }
           />
+          {state.withPagination ? (
+            <Switch
+              label="Compact pagination"
+              checked={state.paginationCompactMode}
+              onChange={(e) =>
+                update({
+                  paginationCompactMode: e.target.checked,
+                })
+              }
+            />
+          ) : null}
           <div>
             <Text weight="bold">Font Size</Text>
             <Slider

--- a/docs/pages/Properties.tsx
+++ b/docs/pages/Properties.tsx
@@ -174,6 +174,11 @@ export default function Properties() {
                 type: 'OnChangeCallback<DataGridPaginationState>',
                 description: 'Callback when page index or page size changed',
               },
+              {
+                name: 'paginationMode',
+                type: '"default" | "compact"',
+                description: '"compact" mode will only show pagination step without page size and current page info',
+              },
             ],
           },
           {

--- a/src/DataGrid.styles.ts
+++ b/src/DataGrid.styles.ts
@@ -1,10 +1,12 @@
 import { createStyles, CSSObject } from '@mantine/core';
+import { PaginationMode } from './types';
 
 export type DataGridStylesParams = {
   height?: string | number;
   width?: string | number;
   noEllipsis?: boolean;
   withFixedHeader?: boolean;
+  paginationMode?: PaginationMode;
 };
 
 const ellipsis: CSSObject = {
@@ -13,107 +15,110 @@ const ellipsis: CSSObject = {
   whiteSpace: 'nowrap',
 };
 
-export default createStyles((theme, { height, width, noEllipsis, withFixedHeader }: DataGridStylesParams) => ({
-  wrapper: {
-    height: height ? height : undefined,
-    width: width ? width : undefined,
-    overflow: 'hidden',
-  },
-  scrollArea: {
-    position: 'relative',
-  },
-  table: {
-    borderCollapse: 'separate',
-    borderSpacing: 0,
-  },
-  thead: {
-    position: 'relative',
-    '::after': {
-      content: "' '",
-      backgroundColor: theme.colors.dark[4],
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      bottom: 0,
-      height: '2px',
+export default createStyles(
+  (theme, { height, width, noEllipsis, withFixedHeader, paginationMode = 'default' }: DataGridStylesParams) => ({
+    wrapper: {
+      height: height ? height : undefined,
+      width: width ? width : undefined,
+      overflow: 'hidden',
     },
-    ...(withFixedHeader && {
-      position: 'sticky',
-      top: 0,
-      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-      transition: 'box-shadow 150ms ease',
-    }),
-  },
-  tbody: {
-    minHeight: '160px',
-  },
-  tr: {},
-  th: { position: 'relative' },
-  td: {},
-  headerCell: {
-    display: 'flex',
-    width: 'inherit',
-    height: 'inherit',
-    justifyContent: 'space-between',
-  },
-  headerCellContent: {
-    ...(!noEllipsis && ellipsis),
-  },
-  headerCellButtons: {
-    display: 'inline-flex',
-    gap: '4px',
-    alignItems: 'center',
-  },
-  dataCell: {
-    display: 'flex',
-    width: 'inherit',
-    justifyContent: 'space-between',
-  },
-  dataCellContent: {
-    ...(!noEllipsis && ellipsis),
-  },
-  resizer: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    right: 0,
-    width: 4,
-    borderRight: `1px dashed ${theme.colors.dark[5]}`,
-    cursor: 'col-resize',
-    ':hover': {
-      backgroundColor: theme.colors.dark[5],
+    scrollArea: {
+      position: 'relative',
+      paddingBottom: theme.spacing.lg,
     },
-  },
-  sorter: {},
-  filter: {},
-  globalFilter: {},
-  pagination: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-
-    [`@media (min-width: ${theme.breakpoints.xl}px)`]: {
+    table: {
+      borderCollapse: 'separate',
+      borderSpacing: 0,
+    },
+    thead: {
+      position: 'relative',
+      '::after': {
+        content: "' '",
+        backgroundColor: theme.colors.dark[4],
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: '2px',
+      },
+      ...(withFixedHeader && {
+        position: 'sticky',
+        top: 0,
+        backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
+        transition: 'box-shadow 150ms ease',
+      }),
+    },
+    tbody: {
+      minHeight: '160px',
+    },
+    tr: {},
+    th: { position: 'relative' },
+    td: {},
+    headerCell: {
+      display: 'flex',
+      width: 'inherit',
+      height: 'inherit',
       justifyContent: 'space-between',
     },
-  },
-
-  pagination_info: {
-    display: 'none',
-
-    [`@media (min-width: ${theme.breakpoints.xl}px)`]: {
-      display: 'inline-block',
+    headerCellContent: {
+      ...(!noEllipsis && ellipsis),
     },
-  },
-
-  pagination_size: {
-    display: 'none',
-
-    [`@media (min-width: ${theme.breakpoints.xl}px)`]: {
-      display: 'flex',
+    headerCellButtons: {
+      display: 'inline-flex',
+      gap: '4px',
       alignItems: 'center',
-      gap: `${theme.spacing.xs}px`,
     },
-  },
+    dataCell: {
+      display: 'flex',
+      width: 'inherit',
+      justifyContent: 'space-between',
+    },
+    dataCellContent: {
+      ...(!noEllipsis && ellipsis),
+    },
+    resizer: {
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      right: 0,
+      width: 4,
+      borderRight: `1px dashed ${theme.colors.dark[5]}`,
+      cursor: 'col-resize',
+      ':hover': {
+        backgroundColor: theme.colors.dark[5],
+      },
+    },
+    sorter: {},
+    filter: {},
+    globalFilter: {},
+    pagination: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
 
-  pagination_page: {},
-}));
+      [`@media (min-width: ${theme.breakpoints.xl}px)`]: {
+        justifyContent: paginationMode === 'default' ? 'space-between' : 'flex-end',
+      },
+    },
+
+    pagination_info: {
+      display: 'none',
+
+      [`@media (min-width: ${theme.breakpoints.xl}px)`]: {
+        display: 'inline-block',
+      },
+    },
+
+    pagination_size: {
+      display: 'none',
+
+      [`@media (min-width: ${theme.breakpoints.xl}px)`]: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: `${theme.spacing.xs}px`,
+      },
+    },
+
+    pagination_page: {},
+  })
+);

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -51,6 +51,7 @@ export function DataGrid<TData extends RowData>({
   withColumnResizing,
   noFlexLayout,
   pageSizes,
+  paginationMode = 'default',
   debug = false,
   // callbacks
   onPageChange,
@@ -75,6 +76,7 @@ export function DataGrid<TData extends RowData>({
       width,
       noEllipsis,
       withFixedHeader,
+      paginationMode,
     },
     {
       classNames,
@@ -309,6 +311,7 @@ export function DataGrid<TData extends RowData>({
           color={color}
           classes={[classes.pagination, classes.pagination_info, classes.pagination_size, classes.pagination_page]}
           locale={locale}
+          mode={paginationMode}
         />
       )}
     </Stack>

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -1,6 +1,6 @@
 import { Group, Select, Text, Pagination as MantinePagination, Box, MantineNumberSize } from '@mantine/core';
 import { Table } from '@tanstack/react-table';
-import { DataGridLocale } from './types';
+import { DataGridLocale, PaginationMode } from './types';
 
 export const DEFAULT_PAGE_SIZES = ['10', '25', '50', '100'];
 export const DEFAULT_INITIAL_PAGE = 0;
@@ -14,6 +14,7 @@ type PaginationProps<TData> = {
   color: string;
   total?: number;
   locale?: DataGridLocale;
+  mode?: PaginationMode;
 };
 
 export function Pagination<TData>({
@@ -24,6 +25,7 @@ export function Pagination<TData>({
   color = '', // Empty color will follow the primary button color
   total,
   locale,
+  mode = 'default',
 }: PaginationProps<TData>) {
   const pageIndex = table.getState().pagination.pageIndex;
   const pageSize = table.getState().pagination.pageSize;
@@ -43,27 +45,33 @@ export function Pagination<TData>({
 
   return (
     <Box className={classes[0]}>
-      <Text size={fontSize} className={classes[1]}>
-        {locale?.pagination ? (
-          locale.pagination(firstRowNum, lastRowNum, maxRows)
-        ) : (
-          <>
-            Showing <b>{firstRowNum}</b> - <b>{lastRowNum}</b> of <b>{maxRows}</b> result{maxRows === 1 ? '' : 's'}
-          </>
-        )}
-      </Text>
+      {mode === 'default' ? (
+        <Text size={fontSize} className={classes[1]}>
+          {locale?.pagination ? (
+            locale.pagination(firstRowNum, lastRowNum, maxRows)
+          ) : (
+            <>
+              Showing <b>{firstRowNum}</b> - <b>{lastRowNum}</b> of <b>{maxRows}</b> result{maxRows === 1 ? '' : 's'}
+            </>
+          )}
+        </Text>
+      ) : null}
 
       <Group>
         <Box className={classes[2]}>
-          <Text size={fontSize}>{locale?.pageSize || 'Rows per page:'}</Text>
-          <Select
-            data={pageSizes}
-            value={`${table.getState().pagination.pageSize}`}
-            onChange={handlePageSizeChange}
-            sx={() => ({
-              width: '72px',
-            })}
-          />
+          {mode === 'default' ? (
+            <>
+              <Text size={fontSize}>{locale?.pageSize || 'Rows per page:'}</Text>
+              <Select
+                data={pageSizes}
+                value={`${table.getState().pagination.pageSize}`}
+                onChange={handlePageSizeChange}
+                sx={() => ({
+                  width: '72px',
+                })}
+              />
+            </>
+          ) : null}
         </Box>
         <MantinePagination
           size={fontSize}

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type DataGridLocale = {
   globalSearch?: string;
 };
 
+export type PaginationMode = 'default' | 'compact';
 export interface DataGridProps<TData extends RowData>
   extends DefaultProps<DataGridStylesNames, object>,
     ComponentPropsWithoutRef<'div'> {
@@ -81,6 +82,10 @@ export interface DataGridProps<TData extends RowData>
    * Default is `["10", "25", "50", "100"]`
    * */
   pageSizes?: string[];
+  /**
+   * Mode of pagination: default or compact
+   * */
+  paginationMode?: PaginationMode;
 
   /**
    * Callback when page index or page size changed


### PR DESCRIPTION
Closes <!-- mention the issue that you're trying to close with this PR -->

## Description

When we show the table on the small container the original pagination might be too big to be shown.
Compact pagination can solve the problem.

We only show the pagination step without additional component such as current page info and page size selection.

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] Add new props `paginationMode`
- [ ] Add new demo dan docs
- [ ] Add extra padding-bottom on ScrollArea to give a space from the scrollbar

## Live Demo Link

<!-- (Optional) Provide live demo link for testing the result.
It will help a lot when reviewing your pull request. -->

Compact Mode:

<img width="1000" alt="Screen Shot 2022-09-06 at 15 49 23" src="https://user-images.githubusercontent.com/7221389/188591157-c050e53b-1998-4993-b946-c1dbbab90832.png">

