### PR TITLE
docs: add ScrollArea around NavBar examples for low resolutions

### DIFF
--- a/docs/components/Navbar.tsx
+++ b/docs/components/Navbar.tsx
@@ -1,4 +1,13 @@
-import { Button, Avatar, Navbar as MantineNavbar, Stack, Text, NavLink, useMantineColorScheme } from '@mantine/core';
+import {
+  Button,
+  Avatar,
+  Navbar as MantineNavbar,
+  Stack,
+  Text,
+  NavLink,
+  useMantineColorScheme,
+  ScrollArea,
+} from '@mantine/core';
 import { Link, useLocation } from 'react-router-dom';
 import { pages, examples } from '../pages';
 
@@ -30,16 +39,18 @@ export default function Navbar() {
           Examples
         </Text>
       </Stack>
-      {Object.values(examples).map((item) => (
-        <NavLink
-          key={item.path}
-          component={Link}
-          to={item.path}
-          label={item.label}
-          active={location.pathname === item.path}
-          pl="xl"
-        />
-      ))}
+      <ScrollArea>
+        {Object.values(examples).map((item) => (
+          <NavLink
+            key={item.path}
+            component={Link}
+            to={item.path}
+            label={item.label}
+            active={location.pathname === item.path}
+            pl="xl"
+          />
+        ))}
+      </ScrollArea>
     </MantineNavbar>
   );
 }


### PR DESCRIPTION
Closes : none

## Description

I always dev with the devtools opened & using low dimensions, like this

![Screenshot 2022-10-14 at 00 18 33](https://user-images.githubusercontent.com/47224540/195721241-85db23e3-e075-46b7-b0e0-9f794c03742a.png)

and I noticed the examples were not scrollable, which means some were't visible 

## Current Tasks

none

## Live Demo Link

screen provided, but you might want to plug Vercel on this repo so you'd get auto-preview deployments on each PR
