### PR TITLE
fix: stale pageSize cause of missing useEffect deps

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:import/recommended',
     'plugin:import/typescript',
+    'plugin:react-hooks/recommended',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/docs/pages/Filters.tsx
+++ b/docs/pages/Filters.tsx
@@ -1,6 +1,5 @@
-import { Stack, Table, Title, Text, createStyles, Group, SimpleGrid, Card, Divider } from '@mantine/core';
+import { Card, Divider, Stack, Title } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import { Fragment } from 'react';
 import { PropertyTable } from '../components/PropertyTable';
 
 export default function Filters() {

--- a/docs/pages/examples/AsyncExample.tsx
+++ b/docs/pages/examples/AsyncExample.tsx
@@ -55,7 +55,7 @@ export default function AsyncExample() {
 
   useEffect(() => {
     load({ pageIndex: 0, pageSize: 10 });
-  }, []);
+  });
 
   return (
     <DataGrid<Data>

--- a/docs/pages/examples/MinimalExample.tsx
+++ b/docs/pages/examples/MinimalExample.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@mantine/core';
+import { useState } from 'react';
+import { DataGrid } from '../../../src';
+import { Data, demoData } from '../../demoData';
+
+type FetchResponse = {
+  list: Data[];
+  total: number;
+};
+
+function fetchData(page: number, pageSize: number, search: string): Promise<FetchResponse> {
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      const data = demoData.filter(
+        (x) => x.text.includes(search) || x.cat.includes(search) || x.fish.includes(search) || x.city.includes(search)
+      );
+      resolve({
+        list: data.slice(page * pageSize, page * pageSize + pageSize),
+        total: data.length + 2,
+      });
+    }, 1000)
+  );
+}
+
+export default function MinimalExample() {
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<FetchResponse>({ list: [], total: 0 });
+  console.log({ loading }, data);
+
+  return (
+    <>
+      <Button
+        onClick={async () => {
+          setLoading(true);
+          const res = await fetchData(0, 100, '');
+          setData(res);
+          setLoading(false);
+        }}
+      >
+        Fetch data
+      </Button>
+      <DataGrid
+        data={data.list}
+        columns={[
+          { header: 'cat', accessorFn: (row) => row.cat },
+          { header: 'fish', accessorFn: (row) => row.fish },
+          { header: 'city', accessorFn: (row) => row.city },
+          { header: 'value', accessorFn: (row) => row.value },
+        ]}
+        loading={loading}
+      />
+    </>
+  );
+}

--- a/docs/pages/examples/index.ts
+++ b/docs/pages/examples/index.ts
@@ -27,6 +27,10 @@ import LocaleExample from './LocaleExample';
 // @ts-ignore
 import LocaleExampleCode from './LocaleExample.tsx?raw';
 
+import MinimalExample from './MinimalExample';
+// @ts-ignore
+import MinimalExampleCode from './MinimalExample.tsx?raw';
+
 import OnRowClickExample from './OnRowExample';
 // @ts-ignore
 import OnRowClickExampleCode from './OnRowExample.tsx?raw';
@@ -61,6 +65,12 @@ export const examples = {
     path: '/example',
     element: DefaultExample,
     code: DefaultExampleCode,
+  }),
+  minimal: ex({
+    label: 'Minimal example',
+    path: '/example/minimal',
+    element: MinimalExample,
+    code: MinimalExampleCode,
   }),
   customFilter: ex({
     label: 'Custom Filter',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantine-data-grid",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "homepage": "https://kuechlin.github.io/mantine-data-grid/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-import-resolver-typescript": "^3.5.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ specifiers:
   eslint-import-resolver-typescript: ^3.5.1
   eslint-plugin-import: ^2.26.0
   eslint-plugin-prettier: ^4.2.1
+  eslint-plugin-react-hooks: ^4.6.0
   husky: ^8.0.1
   lint-staged: ^13.0.3
   prettier: ^2.7.1
@@ -63,6 +64,7 @@ devDependencies:
   eslint-import-resolver-typescript: 3.5.1_hdzsmr7kawaomymueo2tso6fjq
   eslint-plugin-import: 2.26.0_qidincc6lbiur5hfuez2qbs5ge
   eslint-plugin-prettier: 4.2.1_cabrci5exjdaojcvd6xoxgeowu
+  eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
   husky: 8.0.1
   lint-staged: 13.0.3
   prettier: 2.7.1
@@ -413,7 +415,7 @@ packages:
       cosmiconfig-typescript-loader: 4.1.0_3owiowz3ujipd4k6pbqn3n7oui
       lodash: 4.17.21
       resolve-from: 5.0.0
-      ts-node: 10.9.1_ck2axrxkiif44rdbzjywaqjysa
+      ts-node: 10.9.1_bidgzm5cq2du6gnjtweqqjrrn4
       typescript: 4.8.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -1560,7 +1562,7 @@ packages:
     dependencies:
       '@types/node': 14.18.29
       cosmiconfig: 7.0.1
-      ts-node: 10.9.1_ck2axrxkiif44rdbzjywaqjysa
+      ts-node: 10.9.1_bidgzm5cq2du6gnjtweqqjrrn4
       typescript: 4.8.3
     dev: true
 
@@ -2137,6 +2139,15 @@ packages:
       eslint-config-prettier: 8.5.0_eslint@8.23.1
       prettier: 2.7.1
       prettier-linter-helpers: 1.0.0
+    dev: true
+
+  /eslint-plugin-react-hooks/4.6.0_eslint@8.23.1:
+    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.23.1
     dev: true
 
   /eslint-scope/5.1.1:
@@ -4380,7 +4391,7 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: true
 
-  /ts-node/10.9.1_ck2axrxkiif44rdbzjywaqjysa:
+  /ts-node/10.9.1_bidgzm5cq2du6gnjtweqqjrrn4:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -4399,7 +4410,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.29
+      '@types/node': 18.7.18
       acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -217,11 +217,11 @@ export function DataGrid<TData extends RowData>({
 
   useEffect(() => {
     if (withPagination) {
-      table.setPageSize(initialState?.pagination?.pageSize || DEFAULT_INITIAL_SIZE);
+      table.setPageSize(initialState?.pagination?.pageSize ?? DEFAULT_INITIAL_SIZE);
     } else {
       table.setPageSize(data.length);
     }
-  }, [withPagination]);
+  }, [table, withPagination, data.length, initialState?.pagination?.pageSize]);
 
   return (
     <Stack {...others} spacing={verticalSpacing} className={classes.wrapper}>

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1,4 +1,3 @@
-import { RefCallback, useCallback, useEffect, useImperativeHandle, useState } from 'react';
 import { LoadingOverlay, ScrollArea, Stack, Table as MantineTable, Text } from '@mantine/core';
 import {
   ColumnFiltersState,
@@ -10,22 +9,23 @@ import {
   getSortedRowModel,
   OnChangeFn,
   PaginationState,
-  SortingState,
-  useReactTable,
   RowData,
   RowSelectionState,
+  SortingState,
   Table,
+  useReactTable,
 } from '@tanstack/react-table';
+import { RefCallback, useCallback, useEffect, useImperativeHandle, useState } from 'react';
 import { BoxOff } from 'tabler-icons-react';
 
 import useStyles from './DataGrid.styles';
 
-import { GlobalFilter, globalFilterFn } from './GlobalFilter';
-import { ColumnSorter } from './ColumnSorter';
 import { ColumnFilter } from './ColumnFilter';
+import { ColumnSorter } from './ColumnSorter';
+import { GlobalFilter, globalFilterFn } from './GlobalFilter';
 import { DEFAULT_INITIAL_SIZE, Pagination } from './Pagination';
-import { DataGridProps } from './types';
 import { getRowSelectionColumn } from './RowSelection';
+import { DataGridProps } from './types';
 
 export function useDataGrid<TData extends RowData>(): [Table<TData> | null, RefCallback<Table<TData>>] {
   const [state, setState] = useState<Table<TData> | null>(null);
@@ -125,15 +125,17 @@ export function DataGrid<TData extends RowData>({
   });
   useImperativeHandle(tableRef, () => table);
 
+  const tableSize = table.getTotalSize();
+
   useEffect(() => {
     if (noFlexLayout) {
-      setTableWidth(table.getTotalSize() + 'px');
+      setTableWidth(tableSize + 'px');
     } else if (width) {
       setTableWidth(width + 'px');
     } else {
       setTableWidth('100%');
     }
-  }, [width, noFlexLayout, table.getTotalSize()]);
+  }, [table, width, noFlexLayout, tableSize]);
 
   const handleGlobalFilterChange: OnChangeFn<string> = useCallback(
     (arg0) =>
@@ -145,7 +147,7 @@ export function DataGrid<TData extends RowData>({
           globalFilter: next,
         };
       }),
-    [onSearch]
+    [table, onSearch]
   );
 
   const handleSortingChange: OnChangeFn<SortingState> = useCallback(
@@ -158,7 +160,7 @@ export function DataGrid<TData extends RowData>({
           sorting: next,
         };
       }),
-    [onSort]
+    [table, onSort]
   );
 
   const handleColumnFiltersChange: OnChangeFn<ColumnFiltersState> = useCallback(
@@ -171,7 +173,7 @@ export function DataGrid<TData extends RowData>({
           columnFilters: next,
         };
       }),
-    [onFilter]
+    [table, onFilter]
   );
 
   const handlePaginationChange: OnChangeFn<PaginationState> = useCallback(
@@ -186,7 +188,7 @@ export function DataGrid<TData extends RowData>({
         }));
       }
     },
-    [onPageChange]
+    [table, onPageChange]
   );
 
   const handleRowSelectionChange: OnChangeFn<RowSelectionState> = useCallback(
@@ -200,7 +202,7 @@ export function DataGrid<TData extends RowData>({
         };
       });
     },
-    [onRowSelectionChange]
+    [table, onRowSelectionChange]
   );
 
   const pageCount = withPagination && total ? Math.ceil(total / table.getState().pagination.pageSize) : undefined;

--- a/src/GlobalFilter.tsx
+++ b/src/GlobalFilter.tsx
@@ -24,7 +24,7 @@ export function GlobalFilter<TData>({ table, className, locale }: GlobalFilterPr
     }, 200);
 
     return () => clearTimeout(timeout);
-  }, [value]);
+  }, [table, value]);
 
   return (
     <TextInput

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -1,4 +1,4 @@
-import { Group, Select, Text, Pagination as MantinePagination, Box, MantineNumberSize } from '@mantine/core';
+import { Box, Group, MantineNumberSize, Pagination as MantinePagination, Select, Text } from '@mantine/core';
 import { Table } from '@tanstack/react-table';
 import { DataGridLocale, PaginationMode } from './types';
 


### PR DESCRIPTION
docs: add MinimalExample

Closes : none, I didnt open an issue

## Description

adding missing useEffects deps, you might want to add the [react-hooks/exhaustive-deps eslint rule](https://www.npmjs.com/package/eslint-plugin-react-hooks) for that, I noticed this isnt the only place with missing deps

## Current Tasks

none

## Live Demo Link

i did add a [MinimalExample](https://github.com/astahmer/mantine-data-grid/commit/72997ae46961a20f32ee69cbb7d70d9c6ee497d0#diff-493e0112b69a987c1da637f97e9623f3d212b206e8e344bf63a281691e34837e) that was buggy before that PR, all the current examples use `withPagination` which solved the problem


basically it goes like this, with an initial state like:
![Screenshot 2022-10-14 at 00 10 00](https://user-images.githubusercontent.com/47224540/195722175-c0523b63-3422-4d58-9bfa-c3add3657ab7.png)

before the PR:
![Screenshot 2022-10-14 at 00 10 06](https://user-images.githubusercontent.com/47224540/195722193-b9354efd-395f-4c8d-946f-04ef0a5ffcf0.png)

after the PR:
![Screenshot 2022-10-14 at 00 13 21](https://user-images.githubusercontent.com/47224540/195722200-a78fe224-b9e8-47e9-9273-910d313dbfa4.png)

