### PR TITLE
fix: pageSize should default to pageSizes[0]

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -217,13 +217,14 @@ export function DataGrid<TData extends RowData>({
     onRowSelectionChange: handleRowSelectionChange,
   }));
 
+  const defaultPageSize = Number(pageSizes?.[0] ?? DEFAULT_INITIAL_SIZE);
   useEffect(() => {
     if (withPagination) {
-      table.setPageSize(initialState?.pagination?.pageSize ?? DEFAULT_INITIAL_SIZE);
+      table.setPageSize(initialState?.pagination?.pageSize ?? defaultPageSize);
     } else {
       table.setPageSize(data.length);
     }
-  }, [table, withPagination, data.length, initialState?.pagination?.pageSize]);
+  }, [table, withPagination, data.length, initialState?.pagination?.pageSize, defaultPageSize]);
 
   return (
     <Stack {...others} spacing={verticalSpacing} className={classes.wrapper}>


### PR DESCRIPTION
Closes : none

## Description

currently it defaults to 10 (from `DEFAULT_INITIAL_SIZE`) when no initialState.pagination.pageSize is defined

## Current Tasks

none

## Live Demo Link

try this in the MinimalExample
<img width="636" alt="Screenshot 2022-10-15 at 00 05 29" src="https://user-images.githubusercontent.com/47224540/195951392-069d3493-b10f-4d8a-b953-bef7f0cba870.png">

