### PR TITLE
fix: useEffect deps AsyncExample

### DIFF
--- a/docs/pages/examples/AsyncExample.tsx
+++ b/docs/pages/examples/AsyncExample.tsx
@@ -55,7 +55,8 @@ export default function AsyncExample() {
 
   useEffect(() => {
     load({ pageIndex: 0, pageSize: 10 });
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <DataGrid<Data>


### PR DESCRIPTION
Closes : none

## Description

AsyncExample is stuck in infinite loop due to state updating after `load` callback then re-called in useEffect without deps

## Current Tasks

 none

## Live Demo Link

https://kuechlin.github.io/mantine-data-grid/#/example/async
