### PR TITLE
fix: navBar ScrollArea needed paddingBottom to see the last item

### DIFF
--- a/docs/components/Navbar.tsx
+++ b/docs/components/Navbar.tsx
@@ -39,7 +39,7 @@ export default function Navbar() {
           Examples
         </Text>
       </Stack>
-      <ScrollArea>
+      <ScrollArea sx={{ paddingBottom: '80px' }}>
         {Object.values(examples).map((item) => (
           <NavLink
             key={item.path}


### PR DESCRIPTION
Closes none

## Description

the last item is not visible without this padding
