### PR TITLE
add "types" to "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/mantine-data-grid.js",
-      "require": "./dist/mantine-data-grid.umd.cjs"
+      "require": "./dist/mantine-data-grid.umd.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/mantine-data-grid.umd.cjs",


### PR DESCRIPTION
## Description

Setting `"moduleResolution": "bundler"` in `tsconfig.json` breaks with this error:

```
Type error: Could not find a declaration file for module 'mantine-data-grid'. '/path/to/project/node_modules/mantine-data-grid/dist/mantine-data-grid.js' implicitly has an 'any' type.
  There are types at '/path/to/project/node_modules/mantine-data-grid/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'mantine-data-grid' library may need to update its package.json or typings.
```

Adding `"types": "./dist/index.d.ts"` fixes this error.